### PR TITLE
Use standard FASTQ /1 and /2 suffices in output

### DIFF
--- a/readset.py
+++ b/readset.py
@@ -94,8 +94,7 @@ class ReadSet(object):
             for i, read in enumerate(readpair):
                 if read is None:
                     continue
-                which = i + 1
-                header = "%s-%s %s" % (qname, which, self.keyvals)
+                header = "%s/%i %s" % (qname, i + 1, self.keyvals)
                 entry = "@%s\n%s\n+\n%s" % (header, read.seq, read.qual)
                 out.append(entry)
         return "\n".join(out) + "\n"
@@ -108,8 +107,7 @@ class ReadSet(object):
             for i, read in enumerate(readpair):
                 if read is None:
                     continue
-                which = i + 1
-                header = "%s-%s %s" % (qname, which, self.keyvals)
+                header = "%s/%i %s" % (qname, i + 1, self.keyvals)
                 file_handle.write("@%s\n%s\n+\n%s\n" % (header, read.seq, read.qual))
 
     def __iter__(self):


### PR DESCRIPTION
Previously readphaser output FASTQ files with paired reads using the suffices `-1` and `-2`, which is quite unusual (and was not recognised by all downstream analysis tools). This change adopts the much more common `/1` and `/2` convention.

Note that I have not tested this change (it would be great to have a test suite but that is a separate issue), I was altered to this issue by the user of one of my scripts which didn't handle `-1` and `-2` style naming.
